### PR TITLE
FIX :: SPA 지원을 위한 Dockerfile 및 NGINX 설정 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN yarn build
 
-FROM busybox:1.36-musl
-WORKDIR /www
-COPY --from=builder /app/dist .
-RUN adduser -D static
-USER static
-EXPOSE 3000
-CMD ["busybox", "httpd", "-f", "-v", "-p", "3000"]
+FROM nginx:stable-alpine AS production
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,8 @@
+server {
+    listen 80;
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## 배경
현재 Dockerfile은 SPA(Single Page Application)의 클라이언트 사이드 라우팅을 제대로 지원하지 않아, 페이지 새로고침 시 404 에러가 발생할 수 있는 상태입니다.

## 해결해야 할 문제
1. 모든 라우트가 index.html로 리다이렉트되어야 함
2. NGINX 설정을 통한 SPA 지원 필요
3. 현재 발생하는 404 에러 해결

## 수정 사항
1. Dockerfile에 NGINX 설정 파일 복사 명령 추가
```dockerfile
COPY nginx.conf /etc/nginx/conf.d/default.conf